### PR TITLE
Increase Upload-File-Size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginxproxy/nginx-proxy
 RUN { \
       echo 'server_tokens off;'; \
-      echo 'client_max_body_size 100m;'; \
+      echo 'client_max_body_size 512m;'; \
     } > /etc/nginx/conf.d/bluespice.conf


### PR DESCRIPTION
Max File Size in bluespice-wiki is 512m . Does not make sense to user a smaller Size here.